### PR TITLE
Update JIRA automatically using the installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ url | URL for JIRA install | String | auto-detected by helper method
 user | user running JIRA | String | jira
 version | JIRA version to install | String | 6.1.5
 
+**Upgrade Notice:** If `['jira']['install_type']` is set to `installer`, then the installer will try to ugrade your Jira instance located in `['jira']['install_path']` (if exists) up to the `['jira']['version']`.
+
+If you want to avoid an unexecеped upgrade, just set or override `['jira']['version']` attribute value to your current Jira version.
+
 ### JIRA Database Attributes
 
 All of these `node['jira']['database']` attributes are overridden by `jira/jira` encrypted data bag (Hosted Chef) or data bag (Chef Solo), if it exists

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,7 +5,6 @@ default['jira']['version']            = '6.4.11'
 default['jira']['user']               = 'jira'
 default['jira']['backup_when_update'] = false
 default['jira']['ssl']                = false
-default['jira']['update']             = false
 
 # Defaults are automatically selected from version via helper functions
 default['jira']['url']      = nil

--- a/libraries/jira.rb
+++ b/libraries/jira.rb
@@ -39,6 +39,24 @@ module Jira
     end
     # rubocop:enable Metrics/AbcSize
 
+    # Detects the current JIRA version.
+    # Returns nil if JIRA isn't installed.
+    #
+    # @return [String] JIRA version
+    def jira_version
+      pom_file = File.join(
+        node['jira']['install_path'],
+        '/atlassian-jira/META-INF/maven/com.atlassian.jira/atlassian-jira-webapp/pom.properties'
+      )
+
+      begin
+        return Regexp.last_match(1) if File.read(pom_file) =~ /^version=(.*)$/
+      rescue Errno::ENOENT
+        # JIRA is not installed
+        return nil
+      end
+    end
+
     # Returns download URL for JIRA artifact
     def jira_artifact_url
       return node['jira']['url'] unless node['jira']['url'].nil?

--- a/recipes/installer.rb
+++ b/recipes/installer.rb
@@ -9,7 +9,7 @@ if jira_version != node['jira']['version']
     )
   end
 
-  remote_file "#{Chef::Config[:file_cache_path]}/atlassian-jira-#{node['jira']['version']}-#{node['jira']['arch']}.bin" do
+  remote_file "#{Chef::Config[:file_cache_path]}/atlassian-jira-#{node['jira']['version']}.bin" do
     source jira_artifact_url
     checksum jira_artifact_checksum
     mode '0755'
@@ -18,6 +18,6 @@ if jira_version != node['jira']['version']
 
   execute "Installing Jira #{node['jira']['version']}" do
     cwd Chef::Config[:file_cache_path]
-    command "./atlassian-jira-#{node['jira']['version']}-#{node['jira']['arch']}.bin -q -varfile atlassian-jira-response.varfile"
+    command "./atlassian-jira-#{node['jira']['version']}.bin -q -varfile atlassian-jira-response.varfile"
   end
 end

--- a/recipes/installer.rb
+++ b/recipes/installer.rb
@@ -1,20 +1,23 @@
-template "#{Chef::Config[:file_cache_path]}/atlassian-jira-response.varfile" do
-  source 'response.varfile.erb'
-  owner 'root'
-  group 'root'
-  mode '0644'
-end
+if jira_version != node['jira']['version']
+  template "#{Chef::Config[:file_cache_path]}/atlassian-jira-response.varfile" do
+    source 'response.varfile.erb'
+    owner 'root'
+    group 'root'
+    mode '0644'
+    variables(
+      'update' => Dir.exist?(node['jira']['install_path'])
+    )
+  end
 
-remote_file "#{Chef::Config[:file_cache_path]}/atlassian-jira-#{node['jira']['version']}-#{node['jira']['arch']}.bin" do
-  source jira_artifact_url
-  checksum jira_artifact_checksum
-  mode '0755'
-  action :create_if_missing
-  notifies :run, "execute[Installing Jira #{node['jira']['version']}]", :immediately
-end
+  remote_file "#{Chef::Config[:file_cache_path]}/atlassian-jira-#{node['jira']['version']}-#{node['jira']['arch']}.bin" do
+    source jira_artifact_url
+    checksum jira_artifact_checksum
+    mode '0755'
+    action :create
+  end
 
-execute "Installing Jira #{node['jira']['version']}" do
-  cwd Chef::Config[:file_cache_path]
-  command "./atlassian-jira-#{node['jira']['version']}-#{node['jira']['arch']}.bin -q -varfile atlassian-jira-response.varfile"
-  not_if { node['jira']['update'] == false && ::File.directory?("#{node['jira']['install_path']}") }
+  execute "Installing Jira #{node['jira']['version']}" do
+    cwd Chef::Config[:file_cache_path]
+    command "./atlassian-jira-#{node['jira']['version']}-#{node['jira']['arch']}.bin -q -varfile atlassian-jira-response.varfile"
+  end
 end

--- a/spec/installer_spec.rb
+++ b/spec/installer_spec.rb
@@ -2,6 +2,74 @@ require 'spec_helper'
 
 describe 'jira::installer' do
   let(:chef_run) do
-    ChefSpec::Runner.new.converge(described_recipe)
+    ChefSpec::SoloRunner.new do |node|
+      node.set['jira']['version'] = '6.4.7'
+      node.set['jira']['install_path'] = '/foo/jira'
+      node.automatic['kernel']['machine'] = 'x86_64'
+    end.converge(described_recipe)
+  end
+
+  context 'When JIRA is not installed' do
+    before do
+      allow_any_instance_of(Chef::Recipe).to receive(:jira_version).and_return(nil)
+    end
+
+    it 'renders a response file for clean installation' do
+      expect(chef_run).to render_file('/var/cache/chef/atlassian-jira-response.varfile')
+        .with_content { |content|
+          expect(content).to include('sys.confirmedUpdateInstallationString=false')
+        }
+    end
+
+    it 'downloads the installer' do
+      expect(chef_run).to create_remote_file('/var/cache/chef/atlassian-jira-6.4.7.bin')
+        .with(
+          source: 'http://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-6.4.7-x64.bin',
+          checksum: '95db7901de1f0c3d346b6ce716cbdf8cd7dc8333024c26b4620be78ba70f3212'
+        )
+    end
+
+    it 'installs JIRA' do
+      expect(chef_run).to run_execute('Installing Jira 6.4.7')
+        .with(command: './atlassian-jira-6.4.7.bin -q -varfile atlassian-jira-response.varfile')
+    end
+  end
+
+  context 'When other JIRA version is installed' do
+    before do
+      allow_any_instance_of(Chef::Recipe).to receive(:jira_version).and_return('6.3.15')
+    end
+
+    it 'renders a response file for update' do
+      allow(Dir).to receive(:exist?).with('/foo/jira').and_return(true)
+
+      expect(chef_run).to render_file('/var/cache/chef/atlassian-jira-response.varfile')
+        .with_content { |content|
+          expect(content).to include('sys.confirmedUpdateInstallationString=true')
+        }
+    end
+
+    it 'downloads the installer' do
+      expect(chef_run).to create_remote_file('/var/cache/chef/atlassian-jira-6.4.7.bin')
+        .with(
+          source: 'http://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-6.4.7-x64.bin',
+          checksum: '95db7901de1f0c3d346b6ce716cbdf8cd7dc8333024c26b4620be78ba70f3212'
+        )
+    end
+
+    it 'installs JIRA' do
+      expect(chef_run).to run_execute('Installing Jira 6.4.7')
+        .with(command: './atlassian-jira-6.4.7.bin -q -varfile atlassian-jira-response.varfile')
+    end
+  end
+
+  context 'When the appropriate JIRA version is already installed' do
+    before do
+      allow_any_instance_of(Chef::Recipe).to receive(:jira_version).and_return('6.4.7')
+    end
+
+    it 'does not run the installer' do
+      expect(chef_run).not_to run_execute('Installing Jira 6.4.7')
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'chefspec/berkshelf'
 # ChefSpec::Coverage.start!
 
 RSpec.configure do |config|
+  config.file_cache_path = '/var/cache/chef'
   config.log_level = :error
   config.platform = 'ubuntu'
   config.version = '12.04'

--- a/templates/default/response.varfile.erb
+++ b/templates/default/response.varfile.erb
@@ -7,7 +7,7 @@ backupJira$Boolean=<%= node['jira']['backup_when_update'] ? "true" : "false" %>
 app.jiraHome=<%= node['jira']['home_path'] %>
 app.install.service$Boolean=true
 existingInstallationDir=<%= node['jira']['install_path'] %>
-sys.confirmedUpdateInstallationString=<%= node['jira']['update'] ? "true" : "false" %>
+sys.confirmedUpdateInstallationString=<%= @update ? "true" : "false" %>
 sys.languageId=en
 sys.installationDir=<%= node['jira']['install_path'] %>
 executeLauncherAction$Boolean=true


### PR DESCRIPTION
This PR is related to `installer` installation type only.

It include analogue changes from this PR for Confluence cookbook: https://github.com/parallels-cookbooks/confluence/pull/33

Details about auto-update:

- JIRA automated installer supports an unattended upgrade of existing JIRA installation. It works fine and could be very useful for cookbook users.
- It is still easy to control the behavior. Since it compares the value of `['jira']['version']` attribute, it will not upgrade your existing JIRA installation unless you set (or override) this attribute value.
- It saves the recipe idempotence. It means that we will get the desired state regardless of the fact - is JIRA already installed or not. So, we don't need to override `['jira']['update']` after the initial chef-client run. This attribute is now deprecated.

cc: @patcon @mvdkleijn 