### PR TITLE
Redirect HTTP to HTTPS

### DIFF
--- a/templates/default/web_app.conf.erb
+++ b/templates/default/web_app.conf.erb
@@ -18,16 +18,9 @@
   ErrorLog <%= node['jira']['apache2']['error_log'].empty? ? node['apache']['log_dir']+"/jira-error.log" : node['jira']['apache2']['error_log'] %>
   LogLevel warn
 
-  <Proxy *>
-    <% if node['apache'] && node['apache']['version'] == '2.4' %>
-    Require all granted
-    <% else %>
-    Order Deny,Allow
-    Allow from all
-    <% end %>
-  </Proxy>
-  ProxyPass        / http://localhost:<%= node['jira']['tomcat']['port'] %>/ connectiontimeout=5 timeout=300
-  ProxyPassReverse / http://localhost:<%= node['jira']['tomcat']['port'] %>/
+  RewriteEngine On
+  RewriteCond %{HTTPS} off
+  RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI}
 </VirtualHost>
 
 <VirtualHost *:<%= node['jira']['apache2']['ssl']['port'] %>>

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,3 +1,33 @@
 require 'serverspec'
 
 set :backend, :exec
+
+shared_examples_for 'jira behind the apache proxy' do
+  describe 'Tomcat' do
+    describe port(8080) do
+      it { should be_listening }
+    end
+
+    describe command("curl --noproxy localhost 'http://localhost:8080/secure/SetupApplicationProperties!default.jspa' | grep 'JIRA Setup'") do
+      its(:exit_status) { should eq 0 }
+    end
+  end
+
+  describe 'Apache2' do
+    describe port(80) do
+      it { should be_listening }
+    end
+
+    describe port(443) do
+      it { should be_listening }
+    end
+
+    describe command("curl --location --insecure --noproxy localhost 'http://localhost/secure/SetupApplicationProperties!default.jspa' | grep 'JIRA Setup'") do
+      its(:exit_status) { should eq 0 }
+    end
+
+    describe command("curl --insecure --noproxy localhost 'https://localhost/secure/SetupApplicationProperties!default.jspa' | grep 'JIRA Setup'") do
+      its(:exit_status) { should eq 0 }
+    end
+  end
+end

--- a/test/integration/installer-mysql/serverspec/installer-mysql_spec.rb
+++ b/test/integration/installer-mysql/serverspec/installer-mysql_spec.rb
@@ -7,25 +7,5 @@ describe 'MySQL' do
 end
 
 describe 'JIRA' do
-  describe port(8080) do
-    it { should be_listening }
-  end
-
-  describe command("curl --noproxy localhost 'http://localhost:8080/secure/SetupApplicationProperties!default.jspa' | grep 'JIRA Setup'") do
-    its(:exit_status) { should eq 0 }
-  end
-end
-
-describe 'Apache2' do
-  describe port(80) do
-    it { should be_listening }
-  end
-
-  describe port(443) do
-    it { should be_listening }
-  end
-
-  describe command("curl --insecure --noproxy localhost 'https://localhost/secure/SetupApplicationProperties!default.jspa' | grep 'JIRA Setup'") do
-    its(:exit_status) { should eq 0 }
-  end
+  it_behaves_like 'jira behind the apache proxy'
 end

--- a/test/integration/installer-postgresql/serverspec/installer-postgresql_spec.rb
+++ b/test/integration/installer-postgresql/serverspec/installer-postgresql_spec.rb
@@ -7,25 +7,5 @@ describe 'Postgresql' do
 end
 
 describe 'JIRA' do
-  describe port(8080) do
-    it { should be_listening }
-  end
-
-  describe command("curl --noproxy localhost 'http://localhost:8080/secure/SetupApplicationProperties!default.jspa' | grep 'JIRA Setup'") do
-    its(:exit_status) { should eq 0 }
-  end
-end
-
-describe 'Apache2' do
-  describe port(80) do
-    it { should be_listening }
-  end
-
-  describe port(443) do
-    it { should be_listening }
-  end
-
-  describe command("curl --insecure --noproxy localhost 'https://localhost/secure/SetupApplicationProperties!default.jspa' | grep 'JIRA Setup'") do
-    its(:exit_status) { should eq 0 }
-  end
+  it_behaves_like 'jira behind the apache proxy'
 end

--- a/test/integration/standalone-postgresql/serverspec/standalone-postgresql_spec.rb
+++ b/test/integration/standalone-postgresql/serverspec/standalone-postgresql_spec.rb
@@ -13,25 +13,5 @@ describe 'Postgresql' do
 end
 
 describe 'JIRA' do
-  describe port(8080) do
-    it { should be_listening }
-  end
-
-  describe command("curl --noproxy localhost 'http://localhost:8080/secure/SetupApplicationProperties!default.jspa' | grep 'JIRA Setup'") do
-    its(:exit_status) { should eq 0 }
-  end
-end
-
-describe 'Apache2' do
-  describe port(80) do
-    it { should be_listening }
-  end
-
-  describe port(443) do
-    it { should be_listening }
-  end
-
-  describe command("curl --insecure --noproxy localhost 'https://localhost/secure/SetupApplicationProperties!default.jspa' | grep 'JIRA Setup'") do
-    its(:exit_status) { should eq 0 }
-  end
+  it_behaves_like 'jira behind the apache proxy'
 end


### PR DESCRIPTION
Documentation page:
https://confluence.atlassian.com/jira/integrating-jira-with-apache-using-ssl-203395380.html#IntegratingJIRAwithApacheusingSSL-2.3RedirectHTTPtoHTTPS

And, since we add a global rewrite rule, then we don't need to configure proxy for HTTP-based virtual host anymore.

I also modified an integration tests according to these changes - I've added "--location" flag for curl.