### PR TITLE
Better accomodate systems whose node['fqdn'] is `nil` on first run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## x.y.z (pending)
 
+* Converted `virtual_host_name` and `virtual_host_alias` derived attrs
+  into helper methods for templates, etc.
+[[#45]](https://github.com/afklm/jira/issues/45)
+
 ## 2.7.0
 
 * Added support for JIRA 7.0

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,8 +15,11 @@ default['jira']['checksum'] = nil
 default['jira']['apache2']['access_log']         = ''
 default['jira']['apache2']['error_log']          = ''
 default['jira']['apache2']['port']               = 80
-default['jira']['apache2']['virtual_host_name']  = node['fqdn']
-default['jira']['apache2']['virtual_host_alias'] = node['hostname']
+
+# Defaults are automatically selected from fqdn and hostname via helper functions
+default['jira']['apache2']['virtual_host_name']  = nil # node['fqdn']
+default['jira']['apache2']['virtual_host_alias'] = nil # node['hostname']
+
 
 default['jira']['apache2']['ssl']['access_log']       = ''
 default['jira']['apache2']['ssl']['error_log']        = ''

--- a/libraries/jira.rb
+++ b/libraries/jira.rb
@@ -39,6 +39,14 @@ module Jira
     end
     # rubocop:enable Metrics/AbcSize
 
+    def jira_virtual_host_name
+      node['jira']['apache2']['virtual_host_name'] || node['fqdn']
+    end
+
+    def jira_virtual_host_alias
+      node['jira']['apache2']['virtual_host_alias'] || node['hostname']
+    end
+
     # Detects the current JIRA version.
     # Returns nil if JIRA isn't installed.
     #
@@ -235,3 +243,5 @@ end
 
 ::Chef::Recipe.send(:include, Jira::Helpers)
 ::Chef::Resource.send(:include, Jira::Helpers)
+::Chef::Mixin::Template::TemplateContext.send(:include, Jira::Helpers)
+

--- a/recipes/apache2.rb
+++ b/recipes/apache2.rb
@@ -6,4 +6,4 @@ include_recipe 'apache2::mod_proxy'
 include_recipe 'apache2::mod_proxy_http'
 include_recipe 'apache2::mod_ssl'
 
-web_app node['jira']['apache2']['virtual_host_alias']
+web_app jira_virtual_host_alias

--- a/templates/default/tomcat/server.xml.erb
+++ b/templates/default/tomcat/server.xml.erb
@@ -71,7 +71,7 @@
                    maxHttpHeaderSize="8192"
                    protocol="HTTP/1.1"
                    useBodyEncodingForURI="true"
-                   proxyName="<%= node['jira']['apache2']['virtual_host_name'] %>"
+                   proxyName="<%= jira_virtual_host_name %>"
                    secure="true"
                    scheme="https"
                    proxyPort="<%= node['jira']['apache2']['ssl']['port'] %>"

--- a/templates/default/web_app.conf.erb
+++ b/templates/default/web_app.conf.erb
@@ -3,12 +3,11 @@
 # Local modifications will be overwritten by Chef.
 #
 <VirtualHost *:<%= node['jira']['apache2']['port'] %>>
-  <% unless node['jira']['apache2']['virtual_host_name'].empty? -%>
-  ServerName <%= node['jira']['apache2']['virtual_host_name'] %>
+  <% unless jira_virtual_host_name.nil? || jira_virtual_host_name.empty? -%>
+  ServerName <%= jira_virtual_host_name %>
   <% end -%>
-  <% unless node['jira']['apache2']['virtual_host_alias'].empty? -%>
-  <% virtual_host_aliases = node['jira']['apache2']['virtual_host_alias'].kind_of?(Array) ? node['jira']['apache2']['virtual_host_alias'] : [ node['jira']['apache2']['virtual_host_alias'] ] -%>
-  <% virtual_host_aliases.each do |virtual_host_alias| -%>
+  <% unless jira_virtual_host_alias.nil? || jira_virtual_host_alias.empty? -%>
+  <% Array(jira_virtual_host_alias).each do |virtual_host_alias| -%>
   ServerAlias <%= virtual_host_alias %>
   <% end -%>
   <% end -%>
@@ -24,12 +23,11 @@
 </VirtualHost>
 
 <VirtualHost *:<%= node['jira']['apache2']['ssl']['port'] %>>
-  <% unless node['jira']['apache2']['virtual_host_name'].empty? -%>
-  ServerName <%= node['jira']['apache2']['virtual_host_name'] %>
+  <% unless jira_virtual_host_name.nil? || jira_virtual_host_name.empty? -%>
+  ServerName <%= jira_virtual_host_name %>
   <% end -%>
-  <% unless node['jira']['apache2']['virtual_host_alias'].empty? -%>
-  <% virtual_host_aliases = node['jira']['apache2']['virtual_host_alias'].kind_of?(Array) ? node['jira']['apache2']['virtual_host_alias'] : [ node['jira']['apache2']['virtual_host_alias'] ] -%>
-  <% virtual_host_aliases.each do |virtual_host_alias| -%>
+  <% unless jira_virtual_host_alias.nil? || jira_virtual_host_alias.empty? -%>
+  <% Array(jira_virtual_host_alias).each do |virtual_host_alias| -%>
   ServerAlias <%= virtual_host_alias %>
   <% end -%>
   <% end -%>


### PR DESCRIPTION
It seems that CentOS (at least on some IaaS providers like DigitalOcean) do not have an fqdn available via `hostname -f` on the first run. In this case, ohai leaves it undefined.

This can be resolved by setting it to something in the `/etc/hosts` file, but then ohai needs to reload. This works fine, so long as everything relying on `node['fqdn']` can be [lazily evaluated](https://docs.chef.io/resource_common.html#lazy-evaluation).

It seems to pose problems when we're setting the `jira['apache2']['virtual_host_name'] = node['fqdn']` in the attributes file, and then use it extensively in the web_app.conf.erb file:
https://github.com/afklm/jira/blob/master/templates/default/web_app.conf.erb

I think the best solution would involve removing the direct `node` object usage in the template, and instead pass it into the `web_app` definition as variables that can be `lazy {}` expressed.