### PR TITLE
Need more permissive access to home_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## x.y.z (pending)
 
 * Added sensitive true for crowd_sso template
+* Explicitly set `home_path` perms.
+  [[#48]](https://github.com/afklm/jira/issues/48)
 
 ## 2.7.0
 

--- a/recipes/standalone.rb
+++ b/recipes/standalone.rb
@@ -16,6 +16,11 @@ user node['jira']['user'] do
   action :create
 end
 
+directory node['jira']['home_path'] do
+  mode 00755
+  action :create
+end
+
 directory ark_prefix_path do
   action :create
   recursive true


### PR DESCRIPTION
Currently running into this on CentOS. It's explained [here](https://www.centos.org/docs/5/html/Deployment_Guide-en-US/s1-users-tools.html):

> [when home is managed] A directory for user juan is created in the /home/ directory. This directory is owned by user juan and group juan. However, it has read, write, and execute privileges *only* for the user **juan**. All other permissions are denied.

I don't think ubuntu enforces this, but on rhel-like OS, it seems that if a user is denied access to a parent dir, it can't access anything below. In this case, other users can't read logs/etc, despite it being explicitly set with `755` perm bits in the recipe.

I think we'd just add a directory permission for home_path of `755` and should solve