### PR TITLE
Disabled noisey diffs during kitchen runs

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,6 +6,8 @@ driver:
 
 provisioner:
   name: chef_zero
+  client_rb:
+    diff_disabled: true
 
 platforms:
 - name: centos-6


### PR DESCRIPTION
Running multiple tests often goes beyond available scrollback, or can
fail out Travis if there is too much output.