### PR TITLE
Set collation to 'C' for PostgreSQL database

### DIFF
--- a/recipes/database.rb
+++ b/recipes/database.rb
@@ -59,6 +59,8 @@ when 'postgresql'
     connection database_connection
     connection_limit '-1'
     encoding 'utf8'
+    collation 'C'
+    template 'template0'
     owner settings['database']['user']
     action :create
   end


### PR DESCRIPTION
According to the JIRA official documentation, PostgreSQL database options `LC_COLLATE` and `LC_CTYPE` should be set to 'C'
Jira 6: https://confluence.atlassian.com/jira/connecting-jira-to-postgresql-185729433.html
Jira 7: https://confluence.atlassian.com/adminjiraserver070/connecting-jira-applications-to-postgresql-749382637.html

It could be achieved by setting `collation 'C'` and `template 'template0'` in `postgresql_database` resource:
https://github.com/chef-cookbooks/database/blob/a274f77/libraries/provider_database_postgresql.rb#L50

Otherwise, some SQL queries could be extremely slow and in the application log there will be errors like this:
```
You are using an unsupported postgres72 collation: en_US.UTF-8. This may cause some functionality to not work.
Please use POSIX.UTF-8 or C.UTF-8 or C or POSIX as the collation instead.
```