### PR TITLE
Fix postgres version in CentOS (and others?)

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -69,6 +69,7 @@ suites:
 - name: installer-postgresql
   run_list:
   - recipe[jira]
+  - recipe[test-helper]
   attributes:
     jira:
       install_type: installer
@@ -97,6 +98,7 @@ suites:
   run_list:
   - recipe[java]
   - recipe[jira]
+  - recipe[test-helper]
   attributes:
     java:
       install_flavor: oracle

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -15,10 +15,16 @@ platforms:
     box: bento/centos-6.7 # vagrant
     image: centos-6-5-x64 # digitalocean
   attributes:
+    # Required as node[:fqdn] is broken on this platform
+    # Context: https://github.com/chef/ohai/pull/648#issuecomment-161147811
     jira:
       apache2:
-        virtual_host_name: localhost
-        virtual_host_alias: localhost
+        virtual_host_name: jira.example.com
+        virtual_host_alias: jira.example.com
+    # Require >= 9.0 for recent Jira versions. This platform doesn't satisfy
+    # by default. (We validate this constraint in postgres test suites.)
+    postgresql:
+      version: '9.0'
 
 - name: ubuntu-12.04
   driver_config:

--- a/Berksfile
+++ b/Berksfile
@@ -5,4 +5,8 @@ metadata
 group :integration do
   cookbook 'apt'
   cookbook 'java'
+  cookbook 'test-helper',
+    # Pending release: Add ohai attribute support (automatic attrs)
+    # Ref: https://github.com/lipro-cookbooks/test-helper/pull/2
+    github: 'lipro-cookbooks/test-helper'
 end

--- a/Berksfile
+++ b/Berksfile
@@ -5,8 +5,5 @@ metadata
 group :integration do
   cookbook 'apt'
   cookbook 'java'
-  cookbook 'test-helper',
-    # Pending release: Add ohai attribute support (automatic attrs)
-    # Ref: https://github.com/lipro-cookbooks/test-helper/pull/2
-    github: 'lipro-cookbooks/test-helper'
+  cookbook 'test-helper'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
   [[GH-57]](https://github.com/afklm/jira/issues/57)
 * Fix standalone directory perms and accompanying CentOS bug.
   [[GH-57]](https://github.com/afklm/jira/issues/57)
+* Lock `postgresql` cookbook to v3.4.16 so that its derived attributes
+  don't mess with our setting of psql version.
+  [[GH-60]](https://github.com/afklm/jira/issues/60)
+* Added tests for proper psql version.
+  [[GH-60]](https://github.com/afklm/jira/issues/60)
 
 ## 2.7.3
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -20,7 +20,10 @@ depends 'java'
 depends 'mysql', '~> 6.0'
 depends 'mysql_connector'
 depends 'mysql2_chef_gem'
-depends 'postgresql'
+# Due to revert of PR hw-cookbooks/postgresql#201
+# See: https://github.com/hw-cookbooks/postgresql/pull/201
+# See: https://github.com/hw-cookbooks/postgresql/commit/b76660bb225b6b09c8bd54273abe5092164114a6
+depends 'postgresql', '3.4.16'
 
 supports 'centos', '>= 6.0'
 supports 'redhat', '>= 6.0'

--- a/recipes/database.rb
+++ b/recipes/database.rb
@@ -45,6 +45,10 @@ when 'mysql'
     action [:create, :grant]
   end
 when 'postgresql'
+  # TODO: Should this be in attributes file?
+  if node['platform_family'] == 'rhel'
+    node.default['postgresql']['enable_pgdg_yum'] = true
+  end
   include_recipe 'postgresql::server'
   include_recipe 'database::postgresql'
   database_connection.merge!(:username => 'postgres', :password => node['postgresql']['password']['postgres'])

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,6 +1,21 @@
 require 'serverspec'
+require 'json'
 
 set :backend, :exec
+
+$node = ::JSON.parse(File.read('/tmp/test-helper/node.json'))
+
+shared_examples_for 'postgresql' do
+  $node['postgresql']['server']['packages'].each do |pkg|
+    describe package(pkg) do
+      its(:version) { should >= '9.0' }
+    end
+  end
+
+  describe port(5432) do
+    it { should be_listening }
+  end
+end
 
 shared_examples_for 'jira behind the apache proxy' do
   describe 'Tomcat' do

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -4,10 +4,10 @@ require 'json'
 set :backend, :exec
 
 file = '/tmp/test-helper/node.json'
-$node = File.exist?(file) ? ::JSON.parse(File.read(file)) : {}
+node = File.exist?(file) ? ::JSON.parse(File.read(file)) : {}
 
 shared_examples_for 'postgresql' do
-  $node['postgresql']['server']['packages'].each do |pkg|
+  node['postgresql']['server']['packages'].each do |pkg|
     describe package(pkg) do
       its(:version) { should >= '9.0' }
     end

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -3,7 +3,8 @@ require 'json'
 
 set :backend, :exec
 
-$node = ::JSON.parse(File.read('/tmp/test-helper/node.json'))
+file = '/tmp/test-helper/node.json'
+$node = File.exist?(file) ? ::JSON.parse(File.read(file)) : {}
 
 shared_examples_for 'postgresql' do
   $node['postgresql']['server']['packages'].each do |pkg|

--- a/test/integration/installer-postgresql/serverspec/installer_postgresql_spec.rb
+++ b/test/integration/installer-postgresql/serverspec/installer_postgresql_spec.rb
@@ -1,18 +1,7 @@
 require 'spec_helper'
-require 'json'
-
-$node = ::JSON.parse(File.read('/tmp/test-helper/node.json'))
 
 describe 'Postgresql' do
-  $node['postgresql']['client']['packages'].each do |pkg|
-    describe package(pkg) do
-      its(:version) { should >= '9.0' }
-    end
-  end
-
-  describe port(5432) do
-    it { should be_listening }
-  end
+  it_behaves_like 'postgresql'
 end
 
 describe 'JIRA' do

--- a/test/integration/installer-postgresql/serverspec/installer_postgresql_spec.rb
+++ b/test/integration/installer-postgresql/serverspec/installer_postgresql_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
+require 'json'
+
+$node = ::JSON.parse(File.read('/tmp/test-helper/node.json'))
 
 describe 'Postgresql' do
+  describe command('psql --version') do
+    its(:stdout) { should contain($node['postgresql']['version']) }
+  end
+
   describe port(5432) do
     it { should be_listening }
   end

--- a/test/integration/installer-postgresql/serverspec/installer_postgresql_spec.rb
+++ b/test/integration/installer-postgresql/serverspec/installer_postgresql_spec.rb
@@ -4,8 +4,10 @@ require 'json'
 $node = ::JSON.parse(File.read('/tmp/test-helper/node.json'))
 
 describe 'Postgresql' do
-  describe command('psql --version') do
-    its(:stdout) { should contain($node['postgresql']['version']) }
+  $node['postgresql']['client']['packages'].each do |pkg|
+    describe package(pkg) do
+      its(:version) { should >= '9.0' }
+    end
   end
 
   describe port(5432) do

--- a/test/integration/standalone-postgresql/serverspec/standalone_postgresql_spec.rb
+++ b/test/integration/standalone-postgresql/serverspec/standalone_postgresql_spec.rb
@@ -1,4 +1,7 @@
 require 'spec_helper'
+require 'json'
+
+$node = ::JSON.parse(File.read('/tmp/test-helper/node.json'))
 
 describe 'Java' do
   describe command('java -version 2>&1') do
@@ -7,6 +10,10 @@ describe 'Java' do
 end
 
 describe 'Postgresql' do
+  describe command('psql --version') do
+    its(:stdout) { should contain($node['postgresql']['version']) }
+  end
+
   describe port(5432) do
     it { should be_listening }
   end

--- a/test/integration/standalone-postgresql/serverspec/standalone_postgresql_spec.rb
+++ b/test/integration/standalone-postgresql/serverspec/standalone_postgresql_spec.rb
@@ -1,7 +1,4 @@
 require 'spec_helper'
-require 'json'
-
-$node = ::JSON.parse(File.read('/tmp/test-helper/node.json'))
 
 describe 'Java' do
   describe command('java -version 2>&1') do
@@ -10,15 +7,7 @@ describe 'Java' do
 end
 
 describe 'Postgresql' do
-  $node['postgresql']['client']['packages'].each do |pkg|
-    describe package(pkg) do
-      its(:version) { should >= '9.0' }
-    end
-  end
-
-  describe port(5432) do
-    it { should be_listening }
-  end
+  it_behaves_like 'postgresql'
 end
 
 describe 'JIRA' do

--- a/test/integration/standalone-postgresql/serverspec/standalone_postgresql_spec.rb
+++ b/test/integration/standalone-postgresql/serverspec/standalone_postgresql_spec.rb
@@ -10,8 +10,10 @@ describe 'Java' do
 end
 
 describe 'Postgresql' do
-  describe command('psql --version') do
-    its(:stdout) { should contain($node['postgresql']['version']) }
+  $node['postgresql']['client']['packages'].each do |pkg|
+    describe package(pkg) do
+      its(:version) { should >= '9.0' }
+    end
   end
 
   describe port(5432) do


### PR DESCRIPTION
Seems that the postgres cookbook (due to a reversion that puts calculated/derived attributes back in) doesn't respect `node['postgresql']['version']` attrs that are set in other cookbook recipes, like ours. So by default, cookbooks are stuck on the default, which happens to be 8.4 on centos, but might happen to be something better on the ubuntu platforms. (It also might be a workaround to set the postgres version on the node, and I believe that might be why the test suite for ubuntu-15.04 seemed to work at one point.)

For now, I've solved this in my wrapper cookbook (where I noticed it due to using a config that 8.4 can't handle), by adding this to the bottom of my `metadata.rb`:

```rb
# Due to revert of PR hw-cookbooks/postgresql#201
# See: https://github.com/hw-cookbooks/postgresql/pull/201
# See: https://github.com/hw-cookbooks/postgresql/commit/b76660bb225b6b09c8bd54273abe5092164114a6
depends 'postgresql', '3.4.16'
```

I can push that change upstream to `jira` cookbook, but we do lose a bunch of recent `postgresql` cookbook history :/

Seems like a rather silly reversion on the face of it (but I'm sure there was good reason at the time), so we might want to voice concern in https://github.com/hw-cookbooks/postgresql/pull/201, or possibly consider the postgresql_lrwp cookbook, as my understanding is that derived attributes are an anti-pattern that is prone to breakage.