### PR TITLE
Added inline links to DB docs

### DIFF
--- a/recipes/database.rb
+++ b/recipes/database.rb
@@ -25,6 +25,7 @@ when 'mysql'
 
   mysql_database settings['database']['name'] do
     connection database_connection
+    # See: https://confluence.atlassian.com/display/JIRAKB/Health+Check%3A+Database+Collation
     collation 'utf8_bin'
     encoding 'utf8'
     action :create
@@ -58,6 +59,7 @@ when 'postgresql'
   postgresql_database settings['database']['name'] do
     connection database_connection
     connection_limit '-1'
+    # See: https://confluence.atlassian.com/display/JIRAKB/Health+Check%3A+Database+Collation
     encoding 'utf8'
     collation 'C'
     template 'template0'


### PR DESCRIPTION
Nothing too important, but just to connect it with the source of truth, for those who might be troubleshooting/auditing in the future -- Atlassian docs are often circuitous, so good to know where settings came from imho :)