### PR TITLE
Add Sponsors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,20 @@ Please see contributing information in: [CONTRIBUTING.md](CONTRIBUTING.md)
 
 * KLM Royal Dutch Airlines
 
+## Sponsors
+
+Development of this cookbook has been generously supported in part by
+the code contributions of the following organizations:
+
+* [University of Pennsylvania](http://www.upenn.edu/)
+  ([@bflad](https://github.com/afklm/jira/commits?author=bflad))
+* [KLM Royal Dutch Airlines](https://www.klm.com/)
+  ([@mvdkleijn](https://github.com/afklm/jira/commits?author=mvdkleijn))
+* [Parallels Inc.](https://www.parallels.com/)
+  ([@legal90](https://github.com/afklm/jira/commits?author=legal90))
+* [Blended Perspectives Inc.](http://www.blendedperspectives.com/)
+  ([@patcon](https://github.com/afklm/jira/commits?author=patcon))
+
 ## License
 
 Please see licensing information in: [LICENSE](LICENSE)


### PR DESCRIPTION
My client, who has been paying for most of my contributions, was wondering about getting this added to the README, much like the confluence cookbook does:
https://github.com/parallels-cookbooks/confluence#sponsors