### PR TITLE
Standalone home_path directory fix

### DIFF
--- a/recipes/configuration.rb
+++ b/recipes/configuration.rb
@@ -4,14 +4,6 @@ if settings['database']['type'] == 'mysql'
   mysql_connector_j "#{node['jira']['install_path']}/lib"
 end
 
-directory File.dirname(node['jira']['home_path']) do
-  owner node['jira']['user']
-  group node['jira']['user']
-  mode 00755
-  action :create
-  recursive true
-end
-
 template "#{node['jira']['home_path']}/dbconfig.xml" do
   source 'dbconfig.xml.erb'
   owner node['jira']['user']

--- a/recipes/standalone.rb
+++ b/recipes/standalone.rb
@@ -1,4 +1,6 @@
 directory File.dirname(node['jira']['home_path']) do
+  owner 'root'
+  group 'root'
   mode 00755
   action :create
   recursive true
@@ -10,11 +12,6 @@ user node['jira']['user'] do
   shell '/bin/bash'
   supports :manage_home => true
   system true
-  action :create
-end
-
-directory node['jira']['home_path'] do
-  mode 00755
   action :create
 end
 


### PR DESCRIPTION
Hi! For standalone installs, create the directory that contains home_path (/var/atlassian/application-data/) with root:root ownership, not jira:jira.

https://github.com/parallels-cookbooks/confluence/blob/04b7f05279cc729d69c4a6fdde3efb6914a59790/recipes/linux_standalone.rb#L20-L26, defines the home_path containing directory with root:root ownership. If the jira cookbook is run on the same node as the confluence cookbook, the two will fight over the ownership at every converge (as I noticed earlier :smile:)

Additionally, home_path itself is created by the user resource and doesn't need defined as a separate directory resource.

All of this is managed by the installer, so we don't need to create it in the configuration recipe that's run for both installer and standalone install types.

Thanks!