### PR TITLE
Fix download URLs from 7.1.9

### DIFF
--- a/libraries/jira.rb
+++ b/libraries/jira.rb
@@ -67,14 +67,18 @@ module Jira
       version  = node['jira']['version']
 
       # JIRA versions >= 7.0.0 have different flavors
-      # Also (at this time) the URLs for flavors unfortunately differ
+      # The URLs for flavors unfortunately differ prior to 7.1.9
       if Gem::Version.new(version) < Gem::Version.new(7)
         product = "#{base_url}/atlassian-jira-#{version}"
       else
-        case node['jira']['flavor']
-        when 'software'
-          product = "#{base_url}/atlassian-jira-#{node['jira']['flavor']}-#{version}-jira-#{version}"
-        when 'core'
+        if Gem::Version.new(version) < Gem::Version.new('7.1.9')
+          case node['jira']['flavor']
+          when 'software'
+            product = "#{base_url}/atlassian-jira-#{node['jira']['flavor']}-#{version}-jira-#{version}"
+          when 'core'
+            product = "#{base_url}/atlassian-jira-#{node['jira']['flavor']}-#{version}"
+          end
+        else
           product = "#{base_url}/atlassian-jira-#{node['jira']['flavor']}-#{version}"
         end
       end


### PR DESCRIPTION
Atlassian appear to have dropped the "-jira-#{version}" suffix from the download URLs as of v7.1.9, so currently the cookbook fails to download JIRA for that version.

Thanks!

https://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-software-7.1.9.tar.gz
https://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-software-7.1.9-x32.bin
https://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-software-7.1.9-x64.bin

https://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-core-7.1.9.tar.gz
https://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-core-7.1.9-x32.bin
https://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-core-7.1.9-x64.bin
