### PR TITLE
Merge 'settings' hashes from attributes and data bag

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,6 +23,10 @@ default['jira']['autotune']['type']    = 'mixed'
 default['jira']['url']      = nil
 default['jira']['checksum'] = nil
 
+# Data bag where credentials and other sensitive data could be stored (optional)
+default['jira']['data_bag_name'] = 'jira'
+default['jira']['data_bag_item'] = 'jira'
+
 default['jira']['apache2']['enabled']            = true
 default['jira']['apache2']['template_cookbook']  = 'jira'
 default['jira']['apache2']['access_log']         = ''

--- a/recipes/configuration.rb
+++ b/recipes/configuration.rb
@@ -1,4 +1,4 @@
-settings = Jira.settings(node)
+settings = merge_jira_settings
 
 if settings['database']['type'] == 'mysql'
   mysql_connector_j "#{node['jira']['install_path']}/lib"

--- a/recipes/container_server_configuration.rb
+++ b/recipes/container_server_configuration.rb
@@ -1,4 +1,4 @@
-settings = Jira.settings(node)
+settings = merge_jira_settings
 
 template "#{node['jira']['install_path']}/bin/permgen.sh" do
   source 'tomcat/permgen.sh.erb'

--- a/recipes/database.rb
+++ b/recipes/database.rb
@@ -1,4 +1,4 @@
-settings = Jira.settings(node)
+settings = merge_jira_settings
 
 database_connection = {
   :host => settings['database']['host'],

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,4 +1,4 @@
-settings = Jira.settings(node)
+settings = merge_jira_settings
 
 include_recipe 'jira::database' if settings['database']['host'] == '127.0.0.1'
 include_recipe "jira::#{node['jira']['install_type']}"


### PR DESCRIPTION
This PR introduces the changes made earlier in Confluence and Stash cookbooks:
https://github.com/parallels-cookbooks/confluence/pull/23
https://github.com/parallels-cookbooks/confluence/pull/74
https://github.com/bflad/chef-stash/pull/44
https://github.com/bflad/chef-stash/pull/126
### Allow using custom names for data bag item

I've added attributes `['jira']['data_bag_name']` and `['jira']['data_bag_item']`, so these became optional and users are able to change names of the data bag and its item.
### Use `jira` nesting level in data bag

I've set `jira` nesting level in data bag instead of `'local'` or `node.chef_environment`.
At this moment it is not predictable - the library method tries to fetch `local` nested dictionary if it is called by Chef Solo. Otherwise, it fetches dictionary `node.environment`. I suggest using an explicit name, `"jira"`, which is the cookbook name. 
Also, it will be easier for users to understand how data bag values are overriding the appropriate attributes. The logic is: _"If I want to override `['jira']['database']['password']` and `['jira']['database']['user']` via data bag, then I have to set these values on the same nesting level in the data bag"._

**Breaking:** Those who currently use data bag to override settings, will have to change the name of the nested dictionary from their current Chef environment to `"jira"`. 
If they still want to have environment-specific configuration, they can rename the data bag item to env name and then override this attribute:

``` ruby
node.set['jira']['data_bag_item'] = node.chef_environment
```
### Merge `settings` hashes from attributes and data bag

Currently in `jira` cookbook we have an issue when we decide to use data bag to override some sensitive data, like database credentials. However, we should also override there all the settings which recipes expect to get from helper method `Jira.settings`.

This helper should not only choose between _attribute values_ vs _databag content_, but should merge these values. That's why we need to use `Chef::Mixin::DeepMerge.deep_merge(...)`. The example is shown below.

Let's assume, that node has the following attributes:

``` ruby
# Attributes
default['jira']['database']['host']     = 'localhost'
default['jira']['database']['name']     = 'jira'
default['jira']['database']['password'] = 'changeit'
default['jira']['database']['user']     = 'jira'
...
default['jira']['database']['pool-min-size'] = '20'
default['jira']['database']['pool-max-size'] = '20'
...
default['jira']['jvm']['minimum_memory']  = '512m'
default['jira']['jvm']['maximum_memory']  = '768m'
```

At the same time there is a `jira` data bag containing the following settings:

``` json
{
  "id": "jira",
  "jira": {
    "database": {
      "user": "overridden_user",
      "password": "overridden_password"
    },
    "jvm": {
      "maximum_memory": "2048m"
    }
  }
}
```

In the result values from attributes will be overridden by settings from the data bag, so no default values are missed:

``` json
# settings
{
  "database": {
    "host": "localhost",
    "name": "jira",
    "user": "overridden_user",
    "password": "overridden_password",
    "pool-min-size": "20",
    "pool-max-size": "20",
    #...
  },
  "jvm": {
    "minimum_memory": "512m",
    "maximum_memory": "2048m"
    #...
  }
  #...
}
```
