### PR TITLE
Don't redirect /server-status for monitoring systems

### DIFF
--- a/templates/default/web_app.conf.erb
+++ b/templates/default/web_app.conf.erb
@@ -20,6 +20,7 @@
 
   RewriteEngine On
   RewriteCond %{HTTPS} off
+  RewriteCond %{REQUEST_URI} !^/server-status
   RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI}
 </VirtualHost>
 


### PR DESCRIPTION
Current Apache template doesn't allow to access /server-status (https://httpd.apache.org/docs/2.4/mod/mod_status.html) by any monitoring system.
This PR resolve this problem and doesn't affect security because you can disable /server-status location in httpd.conf file.