### PR TITLE
Update standalone installation to support chef-client 13+

### DIFF
--- a/recipes/standalone.rb
+++ b/recipes/standalone.rb
@@ -10,7 +10,7 @@ user node['jira']['user'] do
   comment 'JIRA Service Account'
   home node['jira']['home_path']
   shell '/bin/bash'
-  supports :manage_home => true
+  manage_home true
   system true
   action :create
 end


### PR DESCRIPTION
Fixes this error on newer chef-clients:

```
  
  NoMethodError
  -------------
  undefined method `supports' for Chef::Resource::User::LinuxUser
  
```